### PR TITLE
ci: build a docker image and push to ghcr registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   push:
     branches: [ main, master ]
+    tags: [ v*.*.* ]
   pull_request:
     branches: [ main, master ]
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,3 +22,69 @@ jobs:
     
     - name: Test
       run: go test -v ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    permissions:
+      contents: write
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: '${{ github.actor }}'
+        password: '${{ secrets.GITHUB_TOKEN }}'
+    
+    - name: Get branch names
+      id: branch-name
+      uses: tj-actions/branch-names@v8
+      with:
+        strip_tag_prefix: v
+
+    - name: Generate Docker tags
+      id: docker
+      run: |
+        IMG_NAME="ghcr.io/${GITHUB_REPOSITORY,,}"
+
+        PLATFORMS="linux/amd64"
+        PUSH="false"
+        TAGS="${IMG_NAME}:${{ github.sha }}"
+
+        if [ "${{ steps.branch-name.outputs.is_tag }}" = "true"  ]; then
+          # Add latest tag
+          TAGS="${TAGS},${IMG_NAME}:latest"
+
+          # Add versioned tag, without the "v"
+          TAGS="${TAGS},${IMG_NAME}:${steps.branch-name.outputs.tag}"
+
+          # Build additional image architectures
+          PLATFORMS="${PLATFORMS},linux/arm64"
+
+          # Always push to registry
+          PUSH="true"
+        else
+          # Push if main branch
+          PUSH="${{ github.ref == 'refs/heads/main' }}"
+        fi
+
+        echo "platforms=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+        echo "push=${PUSH}" >> "$GITHUB_OUTPUT"
+        echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        platforms: ${{ steps.docker.outputs.platforms }}
+        push: ${{ steps.docker.outputs.push }}
+        tags: ${{ steps.docker.outputs.tags }}


### PR DESCRIPTION
Builds the Docker image and pushes to the local registry.

Rules:
 - if tag (in format `v*.*.*`), build and pushes:
   - `linux/amd64` and `linux/arm64` images
   - `latest` tag
   - versioned tag (eg, for Git tag `v1.2.3`, creates `:1.2.3`
   - tag with commit's SHA
 - if non-tag, builds:
   - `linux/amd64` image
   - tag with commit's SHA
   - only pushes if in `main` branch